### PR TITLE
Add warning to highlight using string selectors in mixin functions

### DIFF
--- a/transforms/replace-mixins/index.js
+++ b/transforms/replace-mixins/index.js
@@ -29,6 +29,11 @@ module.exports = function transformer(file, api) {
       })
       .forEach(path => {
         let args = path.value.arguments;
+        if (args[0].type === 'StringLiteral') {
+          console.log(
+            `[ember-lifeline-codemod ACTION REQUIRED] filename: ${file.path}\nYou must provide an element (not a DOM selector) as an argument to \`${path.value.callee.property.name}\``,
+          );
+        }
         let newArgs = [j.identifier('this'), ...args];
         if (path.value.callee.property.name === 'addEventListener') {
           hasInjectedAddEventListener = true;


### PR DESCRIPTION
Highlights cases like:

``` js
this.addEventListener('.some-selector', 'click', this.handleClick)
```

as this will trigger a `Must provide an element (not a DOM selector)` error when converted to `addEventListener`.